### PR TITLE
refactor: update Python workflow and restructure requirements

### DIFF
--- a/.github/workflows/py.yml
+++ b/.github/workflows/py.yml
@@ -24,7 +24,25 @@ jobs:
             python-version: 3.12
 
         - name: install dependencies
-          run: pip install -r requirements.txt
+          run: pip install -r API/requirements.txt
 
         - name: code linting
           run: ruff check
+
+        - name: type checking
+          run: python3 -m mypy .
+
+    tests: 
+        name: Linting
+        runs-on: ubuntu-latest
+
+        steps:
+        - uses: actions/checkout@v2
+        - name: set up Python 3.12
+          uses: actions/setup-python@v2
+          with:
+            python-version: 3.12
+        - name: install dependencies
+          run: pip install -r API/requirements.txt
+        - name: test
+          run: python3 -m pytest

--- a/.github/workflows/py.yml
+++ b/.github/workflows/py.yml
@@ -33,7 +33,7 @@ jobs:
           run: python3 -m mypy .
 
     tests: 
-        name: Linting
+        name: Tests
         runs-on: ubuntu-latest
 
         steps:

--- a/API/API/settings.py
+++ b/API/API/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'django-insecure-lobp1t87(a-#7nuh34c366egx_t%k%7b51#hivva)_pxj!0chc
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS: list[str] = []
 
 
 # Application definition

--- a/API/requirements.txt
+++ b/API/requirements.txt
@@ -1,0 +1,14 @@
+asgiref==3.8.1
+Django==5.1.3
+django-stubs==5.1.1
+django-stubs-ext==5.1.1
+iniconfig==2.0.0
+mypy==1.13.0
+mypy-extensions==1.0.0
+packaging==24.2
+pluggy==1.5.0
+pytest==8.3.3
+ruff==0.7.4
+sqlparse==0.5.2
+types-PyYAML==6.0.12.20240917
+typing_extensions==4.12.2

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,10 @@
+[mypy]
+plugins =
+    mypy_django_plugin.main
+mypy_path = ./API
+exclude = (?x)(
+    ^API/morpheus/)
+
+
+[mypy.plugins.django-stubs]
+django_settings_module = "API.settings"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-asgiref==3.8.1
-Django==5.1.3
-ruff==0.7.4
-sqlparse==0.5.2


### PR DESCRIPTION
- Modify workflow to install dependencies from API/requirements.txt
- Add type checking step using mypy
- Introduce a new testing job with pytest
- Change ALLOWED_HOSTS to use type hinting in settings.py
- Replace requirements.txt with API/requirements.txt for better organization
- Add mypy configuration for Django support